### PR TITLE
Update Rails

### DIFF
--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.2.6'
+gem 'rails', github: 'rails/rails', branch: '4-2-stable'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use SCSS for stylesheets


### PR DESCRIPTION
Update rails gem to work on ruby 2.4.x version.

Fix Errors:
- ::Fixnum is deprecated
- ::Bignum is deprecated